### PR TITLE
Ec/libomp manual build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,8 +37,14 @@ jobs:
     env:
       CIBW_BEFORE_BUILD: >-
         rm -rf {package}/build
-      CIBW_BEFORE_BUILD_MACOS: >-
-        brew install libomp
+      CIBW_BEFORE_ALL_MACOS: >-
+        git clone https://github.com/llvm/llvm-project.git &&
+        cd llvm-project/openmp &&
+        mkdir build &&
+        cd build &&
+        cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .. &&
+        make &&
+        sudo make install
       CIBW_SKIP: "*-musllinux_aarch64"
     strategy:
       matrix:
@@ -58,8 +64,6 @@ jobs:
       
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0
-        env:
-          MACOSX_DEPLOYMENT_TARGET: 14.0
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,10 +45,10 @@ jobs:
         cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .. &&
         make &&
         sudo make install
-      CIBW_SKIP: "*-musllinux_aarch64"
+      CIBW_SKIP: "*-musllinux_aarch64 *-musllinux_i686 *-musllinux_x86_64"
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14, macos-latest]
         
     steps:
       - name: Checkout repository
@@ -63,7 +63,7 @@ jobs:
           python-version-file: "pyproject.toml"
       
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v2.23.3
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,8 @@ jobs:
         make &&
         sudo make install
       CIBW_SKIP: "*-musllinux_aarch64 *-musllinux_i686 *-musllinux_x86_64"
+      CIBW_ENVIRONMENT_MACOS: >
+        LIBOMP_GITHUB="1"
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13, macos-14, macos-latest]

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,22 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 os_name = platform.system()
 processor_name = platform.processor()
 
-LIBOMP_PATH_ARM = "/usr/local"
-LIBOMP_PATH_X86 = "/usr/local"
+LIBOMP_PATH_ARM = "/opt/homebrew/opt/libomp"
+LIBOMP_PATH_X86 = "/usr/local/opt/libomp"
+LIBOMP_PATH_GITHUB = "/usr/local"
 
 if os_name == "Windows":
     extra_compile_args = ["/openmp"]
     extra_link_args = []
 elif os_name == "Darwin":
-    if processor_name == "arm":
+    if os.environ.get("LIBOMP_GITHUB") == "1":
+        extra_compile_args = [
+            "-Xpreprocessor",
+            "-fopenmp",
+            f"-I{LIBOMP_PATH_GITHUB}/include",
+        ]
+        extra_link_args = [f"-L{LIBOMP_PATH_GITHUB}/lib", "-lomp"]
+    elif processor_name == "arm":
         extra_compile_args = [
             "-Xpreprocessor",
             "-fopenmp",

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 os_name = platform.system()
 processor_name = platform.processor()
 
-LIBOMP_PATH_ARM = "/opt/homebrew/opt/libomp"
-LIBOMP_PATH_X86 = "/usr/local/opt/libomp"
+LIBOMP_PATH_ARM = "/usr/local"
+LIBOMP_PATH_X86 = "/usr/local"
 
 if os_name == "Windows":
     extra_compile_args = ["/openmp"]

--- a/uv.lock
+++ b/uv.lock
@@ -620,11 +620,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.3.7"
+version = "4.3.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/2d/7d512a3913d60623e7eb945c6d1b4f0bddf1d0b7ada5225274c87e5b53d1/platformdirs-4.3.7.tar.gz", hash = "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351", size = 21291, upload-time = "2025-03-19T20:36:10.989Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/45/59578566b3275b8fd9157885918fcd0c4d74162928a5310926887b856a51/platformdirs-4.3.7-py3-none-any.whl", hash = "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94", size = 18499, upload-time = "2025-03-19T20:36:09.038Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request updates the build and packaging workflow to improve compatibility and functionality, particularly for macOS builds. Key changes include enhancing the macOS build environment, updating dependencies, and adding support for a new library path.

### Workflow and environment updates:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L40-R53): Replaced `CIBW_BEFORE_BUILD_MACOS` with `CIBW_BEFORE_ALL_MACOS` to clone, build, and install the OpenMP library from source, ensuring compatibility with macOS builds. Added `CIBW_ENVIRONMENT_MACOS` to set an environment variable for detecting the custom library path. Expanded the `CIBW_SKIP` configuration to exclude additional `musllinux` architectures.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L60-R68): Updated `cibuildwheel` version from `v2.22.0` to `v2.23.3` to leverage the latest features and fixes.

### Codebase updates for macOS compatibility:

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R17-R30): Introduced `LIBOMP_PATH_GITHUB` to define the custom installation path for the OpenMP library. Modified macOS build logic to check for the `LIBOMP_GITHUB` environment variable and use the custom path if set. This ensures compatibility with the newly built OpenMP library.